### PR TITLE
Downgrade traefik

### DIFF
--- a/traefik/Dockerfile
+++ b/traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM traefik:alpine
+FROM traefik:v1.7.26-alpine
 RUN mkdir -p /etc/traefik/acme
 RUN touch /etc/traefik/acme/acme.json
 RUN chmod 600 /etc/traefik/acme/acme.json

--- a/traefik/traefik.toml
+++ b/traefik/traefik.toml
@@ -1,52 +1,28 @@
-logLevel = "INFO"
-defaultEntryPoints = ["https", "http"]
+debug = false
 
-[retry]
+logLevel = "ERROR"
+defaultEntryPoints = ["https","http"]
 
-[docker]
-exposedByDefault = false
-
-
-[Global]
-debug = true
-
-[log]
-level = "DEBUG"
-
-[accessLog]
-# format = "json"
-
-[api]
-# entryPoint = "traefik"
-# rule = "Host(`traefik.domain.com`)"
-dashboard = false
-
-[ping]
-
-# Entrypoints, http and https
 [entryPoints]
-  # http should be redirected to https
   [entryPoints.http]
   address = ":80"
     [entryPoints.http.redirect]
     entryPoint = "https"
-  # https is the default
   [entryPoints.https]
   address = ":443"
-    [entryPoints.https.tls]
-      # Custom SSL certificate
-      # [[entryPoints.https.tls.certificates]]
-      #  certFile = "/certs/ssl.crt"
-      #   keyFile = "/certs/ssl.key"
+  [entryPoints.https.tls]
+
+[retry]
+
+[docker]
+endpoint = "unix:///var/run/docker.sock"
+watch = true
+exposedByDefault = false
 
 [acme]
-email = "dhilip@reckonsys.com"
-storage = "/etc/traefik/acme/acme.json"
+email = "info@reckonsys.com"
+storage = "acme.json"
 entryPoint = "https"
-acmeLogging = true
 onHostRule = true
-# caServer = "https://acme-staging-v02.api.letsencrypt.org/directory"
-# Default: "https://acme-v02.api.letsencrypt.org/directory"
-
-  [acme.dnsChallenge]
-  provider = "route53"
+[acme.httpChallenge]
+entryPoint = "http"


### PR DESCRIPTION
With the current version of traefik, Let's Encrypt is unable to generate/renew SSL certificates. Downgrading traefik fixed it.